### PR TITLE
Fix typos in German docs

### DIFF
--- a/app/Filament/Admin/Resources/CallResource.php.bak
+++ b/app/Filament/Admin/Resources/CallResource.php.bak
@@ -81,7 +81,7 @@ class CallResource extends Resource
                 BadgeColumn::make('call_status')->label('Status')
                     ->formatStateUsing(fn ($s) => [
                         'completed' => 'Fertig',
-                        'no-answer' => 'Kein Antwort',
+                        'no-answer' => 'Keine Antwort',
                         'failed'    => 'Fehlgeschlagen',
                     ][$s] ?? ($s ?? '–'))
                     ->colors([

--- a/askproai_server_analyse_20250324.txt
+++ b/askproai_server_analyse_20250324.txt
@@ -816,7 +816,7 @@ Datum der Erfassung: Mo 24. Mär 10:53:26 CET 2025
 #!/bin/bash
 
 # Umfassendes Backup-Skript für AskProAI
-# Sicherere Variante mit verbesserter Struktur und Funktionalität
+# Sichere Variante mit verbesserter Struktur und Funktionalität
 
 # Basiskonfiguration
 TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)

--- a/backup_cron.txt
+++ b/backup_cron.txt
@@ -5,7 +5,7 @@ Datum der Erfassung: Mo 24. Mär 10:53:26 CET 2025
 #!/bin/bash
 
 # Umfassendes Backup-Skript für AskProAI
-# Sicherere Variante mit verbesserter Struktur und Funktionalität
+# Sichere Variante mit verbesserter Struktur und Funktionalität
 
 # Basiskonfiguration
 TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Umfassendes Backup-Skript für AskProAI
-# Sicherere Variante mit verbesserter Struktur und Funktionalität
+# Sichere Variante mit verbesserter Struktur und Funktionalität
 
 # Basiskonfiguration
 TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)

--- a/var/www/api-gateway/askproai_server_analyse_20250324.txt
+++ b/var/www/api-gateway/askproai_server_analyse_20250324.txt
@@ -816,7 +816,7 @@ Datum der Erfassung: Mo 24. Mär 10:53:26 CET 2025
 #!/bin/bash
 
 # Umfassendes Backup-Skript für AskProAI
-# Sicherere Variante mit verbesserter Struktur und Funktionalität
+# Sichere Variante mit verbesserter Struktur und Funktionalität
 
 # Basiskonfiguration
 TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)

--- a/var/www/api-gateway/backup_cron.txt
+++ b/var/www/api-gateway/backup_cron.txt
@@ -5,7 +5,7 @@ Datum der Erfassung: Mo 24. Mär 10:53:26 CET 2025
 #!/bin/bash
 
 # Umfassendes Backup-Skript für AskProAI
-# Sicherere Variante mit verbesserter Struktur und Funktionalität
+# Sichere Variante mit verbesserter Struktur und Funktionalität
 
 # Basiskonfiguration
 TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)

--- a/var/www/api-gateway/scripts/backup.sh
+++ b/var/www/api-gateway/scripts/backup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Umfassendes Backup-Skript für AskProAI
-# Sicherere Variante mit verbesserter Struktur und Funktionalität
+# Sichere Variante mit verbesserter Struktur und Funktionalität
 
 # Basiskonfiguration
 TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)


### PR DESCRIPTION
## Summary
- fix typo in German call status
- correct "Sichere Variante" wording in backup scripts and docs

## Testing
- `composer test` *(fails: command not found)*