### PR TITLE
Unify Retell AI env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,3 +63,7 @@ AWS_BUCKET=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
 VITE_APP_NAME="${APP_NAME}"
+
+# Retell AI credentials
+RETELL_AI_API_KEY=
+RETELL_AI_BASE_URL=https://api.retell.ai/v1

--- a/app/Services/RetellAIService.php
+++ b/app/Services/RetellAIService.php
@@ -10,8 +10,8 @@ class RetellAIService
 
     public function __construct()
     {
-        $this->apiKey = env('RETELLAI_API_KEY');
-        $this->baseUrl = env('RETELLAI_BASE_URL', 'https://api.retell.ai/v1');
+        $this->apiKey = env('RETELL_AI_API_KEY');
+        $this->baseUrl = env('RETELL_AI_BASE_URL', 'https://api.retell.ai/v1');
     }
 
     public function getCalls($limit = 10)

--- a/askproai_server_analyse_20250324.txt
+++ b/askproai_server_analyse_20250324.txt
@@ -381,8 +381,8 @@ MAIL_FROM_ADDRESS="info@askproai.de"
 MAIL_FROM_NAME="${APP_NAME}"
 CALCOM_API_KEY=cal_live_e9aa2c4d18e0fd79cf4f8dddb90903da
 CALCOM_BASE_URL=https://api.cal.com/v1
-RETELLAI_API_KEY=key_6ff998ba48e842092e04a5455d19
-RETELLAI_BASE_URL=https://api.retell.ai/v1
+RETELL_AI_API_KEY=key_6ff998ba48e842092e04a5455d19
+RETELL_AI_BASE_URL=https://api.retell.ai/v1
 PASSPORT_PRIVATE_KEY=/var/www/api-gateway/storage/oauth-private.key
 PASSPORT_PUBLIC_KEY=/var/www/api-gateway/storage/oauth-public.key
 # Samedi API Konfiguration

--- a/config/retellai.php
+++ b/config/retellai.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    'api_key' => env('RETELLAI_API_KEY'),
+    'api_key' => env('RETELL_AI_API_KEY'),
     'base_url' => 'https://api.retellai.com/v2/create-phone-call', // ✅ KORREKT laut Dokumentation!
 ];

--- a/konfig_dateien.txt
+++ b/konfig_dateien.txt
@@ -32,8 +32,8 @@ MAIL_FROM_ADDRESS="info@askproai.de"
 MAIL_FROM_NAME="${APP_NAME}"
 CALCOM_API_KEY=cal_live_e9aa2c4d18e0fd79cf4f8dddb90903da
 CALCOM_BASE_URL=https://api.cal.com/v1
-RETELLAI_API_KEY=key_6ff998ba48e842092e04a5455d19
-RETELLAI_BASE_URL=https://api.retell.ai/v1
+RETELL_AI_API_KEY=key_6ff998ba48e842092e04a5455d19
+RETELL_AI_BASE_URL=https://api.retell.ai/v1
 PASSPORT_PRIVATE_KEY=/var/www/api-gateway/storage/oauth-private.key
 PASSPORT_PUBLIC_KEY=/var/www/api-gateway/storage/oauth-public.key
 # Samedi API Konfiguration

--- a/var/www/api-gateway/.env.example
+++ b/var/www/api-gateway/.env.example
@@ -63,3 +63,7 @@ AWS_BUCKET=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
 VITE_APP_NAME="${APP_NAME}"
+
+# Retell AI credentials
+RETELL_AI_API_KEY=
+RETELL_AI_BASE_URL=https://api.retell.ai/v1

--- a/var/www/api-gateway/app/Services/RetellAIService.php
+++ b/var/www/api-gateway/app/Services/RetellAIService.php
@@ -10,8 +10,8 @@ class RetellAIService
 
     public function __construct()
     {
-        $this->apiKey = env('RETELLAI_API_KEY');
-        $this->baseUrl = env('RETELLAI_BASE_URL', 'https://api.retell.ai/v1');
+        $this->apiKey = env('RETELL_AI_API_KEY');
+        $this->baseUrl = env('RETELL_AI_BASE_URL', 'https://api.retell.ai/v1');
     }
 
     public function getCalls($limit = 10)

--- a/var/www/api-gateway/askproai_server_analyse_20250324.txt
+++ b/var/www/api-gateway/askproai_server_analyse_20250324.txt
@@ -381,8 +381,8 @@ MAIL_FROM_ADDRESS="info@askproai.de"
 MAIL_FROM_NAME="${APP_NAME}"
 CALCOM_API_KEY=cal_live_e9aa2c4d18e0fd79cf4f8dddb90903da
 CALCOM_BASE_URL=https://api.cal.com/v1
-RETELLAI_API_KEY=key_6ff998ba48e842092e04a5455d19
-RETELLAI_BASE_URL=https://api.retell.ai/v1
+RETELL_AI_API_KEY=key_6ff998ba48e842092e04a5455d19
+RETELL_AI_BASE_URL=https://api.retell.ai/v1
 PASSPORT_PRIVATE_KEY=/var/www/api-gateway/storage/oauth-private.key
 PASSPORT_PUBLIC_KEY=/var/www/api-gateway/storage/oauth-public.key
 # Samedi API Konfiguration

--- a/var/www/api-gateway/config/retellai.php
+++ b/var/www/api-gateway/config/retellai.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    'api_key' => env('RETELLAI_API_KEY'),
+    'api_key' => env('RETELL_AI_API_KEY'),
     'base_url' => 'https://api.retellai.com/v2/create-phone-call', // ✅ KORREKT laut Dokumentation!
 ];

--- a/var/www/api-gateway/konfig_dateien.txt
+++ b/var/www/api-gateway/konfig_dateien.txt
@@ -32,8 +32,8 @@ MAIL_FROM_ADDRESS="info@askproai.de"
 MAIL_FROM_NAME="${APP_NAME}"
 CALCOM_API_KEY=cal_live_e9aa2c4d18e0fd79cf4f8dddb90903da
 CALCOM_BASE_URL=https://api.cal.com/v1
-RETELLAI_API_KEY=key_6ff998ba48e842092e04a5455d19
-RETELLAI_BASE_URL=https://api.retell.ai/v1
+RETELL_AI_API_KEY=key_6ff998ba48e842092e04a5455d19
+RETELL_AI_BASE_URL=https://api.retell.ai/v1
 PASSPORT_PRIVATE_KEY=/var/www/api-gateway/storage/oauth-private.key
 PASSPORT_PUBLIC_KEY=/var/www/api-gateway/storage/oauth-public.key
 # Samedi API Konfiguration


### PR DESCRIPTION
## Summary
- rename Retell AI env keys to `RETELL_AI_API_KEY` and `RETELL_AI_BASE_URL`
- update service and config files to use the new env keys
- extend example env files and docs

## Testing
- `composer install` *(fails: command not found)*