### PR TITLE
Unify Cal.com config base url

### DIFF
--- a/app/Console/Commands/SyncCalcomEventTypes.php
+++ b/app/Console/Commands/SyncCalcomEventTypes.php
@@ -13,10 +13,10 @@ class SyncCalcomEventTypes extends Command
 
     public function handle(): int
     {
-        $apiKey = config('calcom.api_key');
-        $team   = config('calcom.team_slug');   // ← askproai
+        $apiKey = config('services.calcom.api_key');
+        $team   = config('services.calcom.team_slug');   // ← askproai
         $user   = config('calcom.user_slug');   // ← leer
-        $base   = rtrim(config('calcom.base_url'), '/');
+        $base   = rtrim(config('services.calcom.base_url'), '/');
 
         if (! $apiKey) {
             $this->error('❌  CALCOM_API_KEY fehlt in .env');
@@ -28,7 +28,7 @@ class SyncCalcomEventTypes extends Command
         if ($team)      $query .= '&teamUsername=' . $team;
         elseif ($user)  $query .= '&userUsername=' . $user;
 
-        $url  = "{$base}/v1/event-types?{$query}";
+        $url  = "{$base}/event-types?{$query}";
 
         /* ----------- API-Call ------------------------------------------- */
         $resp = Http::acceptJson()->get($url);

--- a/app/Filament/Admin/Widgets/SystemStatus.php
+++ b/app/Filament/Admin/Widgets/SystemStatus.php
@@ -11,7 +11,7 @@ class SystemStatus extends StatsOverviewWidget
     protected function getStats(): array
     {
         $retell = $this->check(config('retellai.base_url'));
-        $cal = $this->check(config('calcom.base_url'));
+        $cal = $this->check(config('services.calcom.base_url'));
 
         return [
             Stat::make('Retell', $retell['label'])->color($retell['color']),

--- a/app/Filament/Widgets/SystemStatus.php
+++ b/app/Filament/Widgets/SystemStatus.php
@@ -11,7 +11,7 @@ class SystemStatus extends StatsOverviewWidget
     protected function getStats(): array
     {
         $retell = $this->check(config('retellai.base_url'));
-        $cal = $this->check(config('calcom.base_url'));
+        $cal = $this->check(config('services.calcom.base_url'));
 
         return [
             Stat::make('Retell', $retell['label'])->color($retell['color']),

--- a/app/Http/Controllers/Api/CalcomBookingController.php
+++ b/app/Http/Controllers/Api/CalcomBookingController.php
@@ -13,8 +13,8 @@ class CalcomBookingController extends Controller
 
     public function __construct()
     {
-        $this->baseUrl = rtrim(config('calcom.base_url'), '/');
-        $this->apiKey  = config('calcom.api_key');
+        $this->baseUrl = rtrim(config('services.calcom.base_url'), '/');
+        $this->apiKey  = config('services.calcom.api_key');
     }
 
     /**  POST /api/calcom/bookings  */
@@ -52,7 +52,7 @@ class CalcomBookingController extends Controller
         }
 
         /* ---------- 4. Call an Cal.com --------------------------------- */
-        $url   = "{$this->baseUrl}/v1/bookings?apiKey={$this->apiKey}";
+        $url   = "{$this->baseUrl}/bookings?apiKey={$this->apiKey}";
         $resp  = Http::acceptJson()->post($url, $data);
 
         return $resp->successful()

--- a/app/Http/Controllers/CalComController.php
+++ b/app/Http/Controllers/CalComController.php
@@ -13,8 +13,8 @@ class CalComController extends Controller
 
     public function __construct()
     {
-        $this->apiKey = config('calcom.api_key');
-        $this->baseUrl = env('CALCOM_BASE_URL', 'https://api.cal.com/v1');
+        $this->apiKey = config('services.calcom.api_key');
+        $this->baseUrl = config('services.calcom.base_url');
     }
 
     public function checkAvailability(Request $request)

--- a/config/calcom.php
+++ b/config/calcom.php
@@ -2,7 +2,7 @@
 
 return [
     /* Basis-URL der REST-API  */
-    'base_url'  => env('CALCOM_BASE', 'https://api.cal.com'),
+    'base_url'  => env('CALCOM_BASE_URL', 'https://api.cal.com'),
 
     /* Dein Secret-Key  */
     'api_key'   => env('CALCOM_API_KEY'),


### PR DESCRIPTION
## Summary
- align Cal.com config to use `CALCOM_BASE_URL`
- update service and controller references
- ping Cal.com via unified config in widgets
- fix event type sync command to work with unified base url

## Testing
- `php --version` *(fails: command not found)*