### PR TITLE
Fix German comments

### DIFF
--- a/app/Http/Controllers/CalcomWebhookController.php
+++ b/app/Http/Controllers/CalcomWebhookController.php
@@ -23,12 +23,12 @@ class CalcomWebhookController extends Controller
      */
     public function handle(Request $request): JsonResponse
     {
-        /* ───── TEMP-DEBUG – Header & Body in calcom-Channel loggen ───── */
+        /* ───── TEMP-DEBUG – Header und Body im Cal.com-Channel loggen ───── */
         Log::channel('calcom')->info('[Debug] headers', $request->headers->all());
         Log::channel('calcom')->info('[Debug] body',    ['raw' => $request->getContent()]);
         /* ──────────────────────────────────────────────────────────────── */
 
-        // TODO: Event-Typen auswerten (booking.created …)
+        // TODO: Eventtypen auswerten (booking.created …)
         Log::channel('calcom')->info('[Cal.com] Webhook-Event', $request->all());
 
         return response()->json(['received' => true]);

--- a/app/Http/Controllers/RetellConversationEndedController.php
+++ b/app/Http/Controllers/RetellConversationEndedController.php
@@ -10,7 +10,7 @@ class RetellConversationEndedController
 {
     public function __invoke(Request $request): Response
     {
-        // TODO: Conversation‑Ended Event verarbeiten
+        // TODO: Conversation-Ended-Event verarbeiten
         Log::info('Retell Conversation Ended', $request->all());
 
         return response()->noContent();   // 204

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,15 +3,15 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\CalcomWebhookController;
-use App\Http\Controllers\RetellWebhookController;   // ← HIERHER!
+use App\Http\Controllers\RetellWebhookController;   // Controller für Retell-Webhook
 
 /*
 |--------------------------------------------------------------------------
-| API Routes
+| API-Routen
 |--------------------------------------------------------------------------
 */
 
-// ---- Cal.com Webhook -------------------------------------------
+// ---- Cal.com-Webhook -------------------------------------------
 
 // 1) Ping-Route (GET)  ➜ ohne Signaturprüfung
 Route::get('calcom/webhook', [CalcomWebhookController::class, 'ping']);
@@ -20,5 +20,5 @@ Route::get('calcom/webhook', [CalcomWebhookController::class, 'ping']);
 Route::post('calcom/webhook', [CalcomWebhookController::class, 'handle'])
      ->middleware('calcom.signature');
 
-// Retell Webhook (POST)
+// Retell-Webhook (POST)
 Route::post('retell/webhook', [RetellWebhookController::class, '__invoke']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,13 +6,7 @@ Route::get('/', function () {
     return view('welcome');
 });
 
-// ---------- Filament Admin-Dashboard als Root des Panels ----------
-// // // Route::redirect('/admin', '/admin/dashboard')
-//      ->middleware('web');        // schützt weiterhin durch Sessions & CSRF
-// ---------- Filament Admin-Dashboard als Root des Panels ----------
-// // // Route::get('/admin', fn () => redirect('/admin/dashboard'))
-//      ->middleware('web');
-// ---------- Filament Admin-Dashboard als Root des Panels ----------
-// // // Route::get('/admin', fn () => redirect('/admin/dashboard'))
-//      ->name('filament.admin.redirect-to-dashboard')
-//      ->middleware('web');
+// ---------- Filament-Admin-Dashboard als Root des Panels ----------
+// Route::redirect('/admin', '/admin/dashboard')
+//     ->name('filament.admin.redirect-to-dashboard')
+//     ->middleware('web');        // schützt weiterhin durch Sessions & CSRF


### PR DESCRIPTION
## Summary
- refine comments in API routes for German consistency
- adjust Cal.com webhook debugging note
- clarify Retell webhook comments
- tweak Retell conversation ended note
- streamline Filament route comments

## Testing
- `phpunit --version` *(fails: command not found)*