### PR TITLE
Fix staff_id line wrapping

### DIFF
--- a/app/Console/Commands/SyncCalcomEventTypes.php
+++ b/app/Console/Commands/SyncCalcomEventTypes.php
@@ -48,7 +48,8 @@ class SyncCalcomEventTypes extends Command
                 [
                     'title'  => $et['title']  ?? $et['name'] ?? '—',
                     'active' => !($et['hidden'] ?? false),
-              'staff_id' =>  \App\Models\CalcomEventType::where('calcom_id', $et['id'])->value('staff_id') ?: null,
+                    'staff_id' => \App\Models\CalcomEventType::where('calcom_id', $et['id'])
+                        ->value('staff_id') ?: null,
                 ]
             );
             $count++;


### PR DESCRIPTION
## Summary
- fix indentation for `staff_id` when syncing event types

## Testing
- `php` not installed, so no tests were run