### PR TITLE
fix: 500 – middleware alias + Kernel property

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -26,7 +26,7 @@ class Kernel extends HttpKernel
     /* -------------------------------------------------------------------- *
      | 2) **Hier** gehören Route-Aliase hin – funktioniert ab Laravel 8-11  |
      * -------------------------------------------------------------------- */
-    protected array $middlewareAliases = [
+    protected $middlewareAliases = [
         // ✨ unsere neue Signatur-Prüfung
         'calcom.signature' => \App\Http\Middleware\VerifyCalcomSignature::class,
         

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -51,6 +51,9 @@ return Application::configure(basePath: dirname(__DIR__))
             /* ✨ Eigener Alias – Cal.com-Webhook-Signaturprüfung */
             'calcom.signature' => \App\Http\Middleware\VerifyCalcomSignature::class,
 
+            /* 🔒 Admin panel security - internal network only */
+            'restrict.internal' => \App\Http\Middleware\RestrictToInternalNetwork::class,
+
             /* ── Laravel-Standard ─────────────────────────────── */
             'auth'              => \App\Http\Middleware\Authenticate::class,
             'auth.basic'        => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,


### PR DESCRIPTION
Stellt 'restrict.internal' wieder her, entfernt typed property im Kernel; Caches regeneriert.