### PR TITLE
fix: restore 'view' binding

### DIFF
--- a/app/Providers/ViewBindingFixServiceProvider.php
+++ b/app/Providers/ViewBindingFixServiceProvider.php
@@ -1,0 +1,15 @@
+<?php
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Illuminate\View\ViewServiceProvider;
+
+class ViewBindingFixServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        if (! $this->app->bound('view')) {
+            $this->app->register(ViewServiceProvider::class);
+        }
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -21,6 +21,9 @@ return Application::configure(basePath: dirname(__DIR__))
         commands: __DIR__.'/../routes/console.php',
         health:   '/up',
     )
+    ->withProviders([
+        App\Providers\ViewBindingFixServiceProvider::class,
+    ])
     ->withMiddleware(function (Middleware $middleware) {
 
         /* ---------------------------------------------------------


### PR DESCRIPTION
Registriert ViewServiceProvider explizit, behebt ReflectionException: Class 'view' does not exist.